### PR TITLE
feat: add keyboard.js with pressKeyboardShortcut

### DIFF
--- a/kit/keyboard.js
+++ b/kit/keyboard.js
@@ -1,0 +1,30 @@
+/**
+ * @description Presses a keyboard shortcut
+ * @param {string} application - the application form which this keyboard shortcut should be run
+ * @param {string} key - a single key such as "j" or "q"
+ * @typedef {('command'|'control'|'option')} Command - 'command' | 'control | 'option'
+ * @param {Command[]} commands - an array of commands.
+ * @example pressKeyboardShortcut("j", ["command", "control"]) would press `j + ⌘ + ^`
+ */
+ export async function pressKeyboardShortcut (application = "", key = "", commands = []) {
+  // We want them as an array for formatCommands so we split on ","
+  const rawCommands = commands.split(",")
+  const formattedCommands = formatCommands(rawCommands)
+  // Note: we have to activate an application first in order to use this script with it
+  // Otherwise, it will run the keyboard shortcut on Script Kit
+  return await applescript(
+    String.raw`
+    activate application "${application}"
+    tell application "System Events"
+      keystroke "${key}" using {${formattedCommands}}
+    end tell
+    `
+  )
+}
+
+function formatCommands(commands = []) {
+  // This will turn ["control", "command"]
+  // into this "control down, command down,"
+  // and then slice the last commma
+  return commands.map(command => `${command} down,`).join(" ").slice(0, -1)
+}


### PR DESCRIPTION
This PR adds a new helper file to kit called `keyboard.js` which exports a function called `pressKeyboardShortcut.js`.

## Demo
![2021-03-17 15 31 46](https://user-images.githubusercontent.com/3806031/111834870-7052de00-88b1-11eb-99ba-0ffbcd990830.gif)


