### PR TITLE
fix(types): Fix scrapeSelector and scrapeAttribute d.ts types and default values

### DIFF
--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -97,8 +97,8 @@ end tell
 global.scrapeSelector = async (
   url: string,
   selector: string,
-  xf: (element: any) => any,
-  { headless, timeout } = { headless: true, timeout: 5000 }
+  xf?: (element: any) => any,
+  { headless = true, timeout = 5000 } = { headless: true, timeout: 5000 }
 ) => {
   /** @type typeof import("playwright") */
   let { chromium } = await global.npm("playwright")
@@ -129,7 +129,7 @@ global.scrapeAttribute = async (
   url: string,
   selector: string,
   attribute: string,
-  { headless, timeout } = { headless: true, timeout: 5000 }
+  { headless = true, timeout = 5000} = { headless: true, timeout: 5000 }
 ) => {
   let { chromium } = await global.npm("playwright")
 

--- a/src/types/platform.d.ts
+++ b/src/types/platform.d.ts
@@ -45,8 +45,8 @@ interface ScrapeSelector {
   (
     url: string,
     selector: string,
-    transform: (element: any) => any,
-    options: ScrapeOptions
+    transform?: (element: any) => any,
+    options?: ScrapeOptions
   )
 }
 interface ScrapeAttribute {
@@ -54,7 +54,7 @@ interface ScrapeAttribute {
     url: string,
     selector: string,
     attribute: string,
-    options: ScrapeOptions
+    options?: ScrapeOptions
   )
 }
 


### PR DESCRIPTION
When using `scrapeSelector` TS complains about missing arguments even though `transform` and `options` are optional.
This PR fixes the types in `platform.d.ts` so that both arguments are optional.

The other issue is that the `options` has a default object but the properties in the object don't have default values. 
This means if you are passing options object with one property the other one will be undefined e.g
```
await scrapeSelector(
	`https://google.com/search?q=${encodeURIComponent(
		query + " " + from + " " + to
	)}`,
	"span[data-value]",
	(el) => el.innerText,
	{ headless: true }
)
```
In the script above `timeout` will be undefined so you either have to provide all options or none.
This PR fixes that by providing default values to the properties as well. 