### PR TITLE
Do not use tmp file to run applescript

### DIFF
--- a/src/platform/darwin.ts
+++ b/src/platform/darwin.ts
@@ -15,8 +15,8 @@ global.applescript = async (
     let stdout = ``
     let stderr = ``
     let child = spawn(
-      `/usr/bin/osascript -e`,
-      script,
+      `/usr/bin/osascript`,
+      ["-e" , script]
       options
     )
 

--- a/src/platform/darwin.ts
+++ b/src/platform/darwin.ts
@@ -11,15 +11,12 @@ global.applescript = async (
   script,
   options = { silent: true }
 ) => {
-  let applescriptPath = tmpPath("latest.scpt")
-  await writeFile(applescriptPath, script)
-
   let p = new Promise<string>((res, rej) => {
     let stdout = ``
     let stderr = ``
     let child = spawn(
-      `/usr/bin/osascript`,
-      [applescriptPath],
+      `/usr/bin/osascript -e`,
+      script,
       options
     )
 


### PR DESCRIPTION
I stumbled upon this and noticed that you don't use -e for osascript - any reason for that?