### PR TITLE
fix(notify): default notify timeout to false

### DIFF
--- a/src/api/packages/node-notifier.ts
+++ b/src/api/packages/node-notifier.ts
@@ -7,9 +7,11 @@ interface Notify {
 }
 
 global.notify = notification => {
-  return typeof notification === "string"
-    ? notifier.notify({ message: notification })
-    : notifier.notify(notification)
+  let options =
+    typeof notification === "string"
+      ? { message: notification }
+      : notification
+  return notifier.notify({ timeout: false, ...options })
 }
 declare global {
   var notify: Notify


### PR DESCRIPTION
> As of Version 6.0 there is a default timeout set of 10 to ensure that the application closes properly. In order to remove the timeout and have an instantly closing notification (does not support actions), set timeout to false.
>
> \- node-notifier readme