### PR TITLE
feat: add open and keep focus option in google search

### DIFF
--- a/src/main/google.ts
+++ b/src/main/google.ts
@@ -17,7 +17,7 @@ let currentInput = ``
 let title = ``
 let url = ``
 
-let onPress = async () => {
+let pasteOptions = async () => {
   let asMarkdown = `[${title}](${url})`
   let asInputMarkdown = `[${currentInput}](${url})`
 
@@ -53,9 +53,20 @@ await arg(
     shortcuts: [
       {
         name: `Paste`,
+        key: `${cmd}+shift+v`,
+        bar: `right`,
+        onPress: pasteOptions,
+      },
+      {
+        name: `Open and keep focus`,
         key: `${cmd}+enter`,
         bar: `right`,
-        onPress,
+        onPress: async () => {
+          setAlwaysOnTop(true)
+          setIgnoreBlur(true)
+          open(url)
+          setTimeout(focus, 100)
+        },
       },
     ],
     onChoiceFocus: async (_, { focused }) => {


### PR DESCRIPTION
# Description

This PR updates the search in google by typing `. It changes the shortcut for paste options from `cmd+enter` to `cmd+shift+v`

And adds a new shortcut `cmd+enter` that opens a new tab in the background and keep focus on the search result. That way you can open multiple options