### PR TITLE
fixes node installation for linux

### DIFF
--- a/build/build-kit.js
+++ b/build/build-kit.js
@@ -45,10 +45,10 @@ let installNodeWin = async () => {
 }
 
 let installNode =
-  platform() === "darwin"
+  platform() !== "win32"
     ? exec(
-        `./build/install-node.sh v16.14.2 --prefix '${knodePath()}'`
-      )
+      `./build/install-node.sh v16.14.2 --prefix '${knodePath()}'`
+    )
     : installNodeWin()
 
 cp("-R", "./root/.", kitPath())


### PR DESCRIPTION
This PR fixes issues related to Linux while building kit SDK.

Installs node executable for Linux instead of windows while building on Linux.