### PR TITLE
feat(editor): get's path of currently active file

### DIFF
--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -5,6 +5,18 @@ global.getActiveTab = async (browser = "Google Chrome") => {
 
   return result.trim()
 }
+global.getActiveVsCodeFilePath = async () => {
+  let result = await applescript(String.raw`
+  tell application "System Events"
+      tell process "Code"
+          set frontmost to true
+          set activeDocPath to value of attribute "AXDocument" of front window
+      end tell
+  end tell
+  return activeDocPath
+`)
+  return result.replace("file://", "")
+}
 
 global.getTabs = async (browser = "Google Chrome") => {
   let result = await applescript(String.raw`


### PR DESCRIPTION
I don't know if that is a good place for it, but vscode is chromium, so it is a browser I can change placement. 
I thought this helper function would be helpful for some jscodeshift scripts or stuff like that so you can append some code to the currently active tab of vscode.