### PR TITLE
Improve playwright and add new commands

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1220,6 +1220,41 @@ If you want to watch the main log, you can use:
 tail -f ~/.kit/logs/kit.log
 ```
 
+
+## Save webpage as a PDF
+
+<!-- value: https://github.com/johnlindquist/kit/edit/main/GUIDE.md -->
+
+You can save any webpage as a PDF.
+
+```js
+// Name: Save news as PDF
+
+import "@johnlindquist/kit"
+
+const pdfResults = await getWebpageAsPdf('https://legiblenews.com');
+
+await writeFile(home('news.pdf'), pdfResults);
+```
+
+## Take screenshot of webpage
+
+<!-- value: https://github.com/johnlindquist/kit/edit/main/GUIDE.md -->
+
+You can take a screenshot of any webpage.
+
+```js
+// Name: Take screenshot of news webpage
+
+import "@johnlindquist/kit"
+
+const screenshotResults = await getScreenshotFromWebpage('https://legiblenews.com', {
+  screenshotOptions: { fullPage: true },
+});
+
+await writeFile(home('news.png'), screenshotResults);
+```
+
 ## Missing Something?
 
 <!-- value: https://github.com/johnlindquist/kit/edit/main/GUIDE.md -->

--- a/src/types/platform.d.ts
+++ b/src/types/platform.d.ts
@@ -51,7 +51,11 @@ interface FocusTab {
 interface ScrapeOptions {
   headless?: boolean
   timeout?: number
-  /** {@link https://playwright.dev/docs/api/class-browser#browser-new-context} */
+  /**
+   * Playwright browser context options.
+   *
+   * {@link https://playwright.dev/docs/api/class-browser#browser-new-context}
+   */
   browserOptions?: BrowserContextOptions
 }
 
@@ -78,9 +82,17 @@ interface ScrapeAttribute {
 }
 interface ScreenshotFromWebpageOptions {
   timeout?: number
-  /** {@link https://playwright.dev/docs/api/class-browser#browser-new-context} */
+  /**
+   * Playwright browser context options.
+   *
+   * {@link https://playwright.dev/docs/api/class-browser#browser-new-context}
+   */
   browserOptions?: BrowserContextOptions
-  /** {@link https://playwright.dev/docs/api/class-page#page-screenshot} */
+  /**
+   * Playwright page screenshot options.
+   *
+   * {@link https://playwright.dev/docs/api/class-page#page-screenshot}
+   */
   screenshotOptions?: PageScreenshotOptions
 }
 
@@ -93,11 +105,23 @@ interface GetScreenshotFromWebpage {
 
 interface WebpageAsPdfOptions {
   timeout?: number
-  /** {@link https://playwright.dev/docs/api/class-browser#browser-new-context} */
+  /**
+   * Playwright browser context options.
+   *
+   * {@link https://playwright.dev/docs/api/class-browser#browser-new-context}
+   */
   browserOptions?: BrowserContextOptions
-  /** {@link https://playwright.dev/docs/api/class-page#page-pdf} */
+  /**
+   * Playwright page pdf options.
+   *
+   * {@link https://playwright.dev/docs/api/class-page#page-pdf}
+   */
   pdfOptions?: Parameters<Page["pdf"]>[0]
-  /** {@link https://playwright.dev/docs/api/class-page#page-emulate-media} */
+  /**
+   * Playwright page emulate media options.
+   *
+   * {@link https://playwright.dev/docs/api/class-page#page-emulate-media}
+   */
   mediaOptions?: Parameters<Page["emulateMedia"]>[0]
 }
 

--- a/src/types/platform.d.ts
+++ b/src/types/platform.d.ts
@@ -1,5 +1,10 @@
 import { ProcessInfo } from "./core"
 import { Display, Point } from "./electron"
+import type {
+  BrowserContextOptions,
+  Page,
+  PageScreenshotOptions,
+} from "playwright"
 
 interface PlayAudioFile {
   (path: string, options?: any): Promise<string>
@@ -46,22 +51,61 @@ interface FocusTab {
 interface ScrapeOptions {
   headless?: boolean
   timeout?: number
+  /** {@link https://playwright.dev/docs/api/class-browser#browser-new-context} */
+  browserOptions?: BrowserContextOptions
 }
-interface ScrapeSelector {
+
+interface ScrapeSelector<T = any> {
   (
     url: string,
     selector: string,
-    transform?: (element: any) => any,
+    /**
+     * Transformation to apply to each DOM node that was selected.
+     * By default, `element.innerText` is returned.
+     */
+    transform?: (element: any) => T,
     options?: ScrapeOptions
-  )
+  ): Promise<T[]>
 }
+
 interface ScrapeAttribute {
   (
     url: string,
     selector: string,
     attribute: string,
     options?: ScrapeOptions
-  )
+  ): Promise<string | null>
+}
+interface ScreenshotFromWebpageOptions {
+  timeout?: number
+  /** {@link https://playwright.dev/docs/api/class-browser#browser-new-context} */
+  browserOptions?: BrowserContextOptions
+  /** {@link https://playwright.dev/docs/api/class-page#page-screenshot} */
+  screenshotOptions?: PageScreenshotOptions
+}
+
+interface GetScreenshotFromWebpage {
+  (
+    url: string,
+    options?: ScreenshotFromWebpageOptions
+  ): Promise<Buffer>
+}
+
+interface WebpageAsPdfOptions {
+  timeout?: number
+  /** {@link https://playwright.dev/docs/api/class-browser#browser-new-context} */
+  browserOptions?: BrowserContextOptions
+  /** {@link https://playwright.dev/docs/api/class-page#page-pdf} */
+  pdfOptions?: Parameters<Page["pdf"]>[0]
+  /** {@link https://playwright.dev/docs/api/class-page#page-emulate-media} */
+  mediaOptions?: Parameters<Page["emulateMedia"]>[0]
+}
+
+interface GetWebpageAsPdf {
+  (
+    url: string,
+    options?: WebpageAsPdfOptions
+  ): Promise<Buffer>
 }
 
 interface Window {
@@ -312,6 +356,8 @@ export interface PlatformApi {
   scatterWindows: ScatterWindows
   scrapeAttribute: ScrapeAttribute
   scrapeSelector: ScrapeSelector
+  getScreenshotFromWebpage: GetScreenshotFromWebpage
+  getWebpageAsPdf: GetWebpageAsPdf
   setActiveAppBounds: SetActiveAppBounds
   setActiveAppPosition: SetActiveAppPosition
   setActiveAppSize: SetActiveAppSize
@@ -362,6 +408,8 @@ declare global {
   var scatterWindows: ScatterWindows
   var scrapeAttribute: ScrapeAttribute
   var scrapeSelector: ScrapeSelector
+  var getScreenshotFromWebpage: GetScreenshotFromWebpage
+  var getWebpageAsPdf: GetWebpageAsPdf
   var setActiveAppBounds: SetActiveAppBounds
   var setActiveAppPosition: SetActiveAppPosition
   var setActiveAppSize: SetActiveAppSize


### PR DESCRIPTION
- Ensure that the playwright browser is always closed
  - Otherwise an error window would potentially pop up
- Added `browserOptions` to web scraping selector/attribute commands
- Added command to export webpage as PDF
- Added command to take a screenshot of a webpage
- Updated Guide to include new commands

@johnlindquist - I have included an import for playwright in `platform.d.ts` - I know this does not work since playwright is not installed in the kit folder - _but I would really love for it to work somehow to get better typing_. It doesn't break anything _(AFAIK - I was not able to run the build process)_, but the types fallback to `any`..

We could inline the types from the library (which I did initially), but they would potentially become outdated and may not match the version of playwright the user has actually installed.

**Let me know if you would prefer that I remove the import to playwright types and change the types to `any`**

------

I also added comments and links to any of the playwright options so the user at least has a chance to discover the proper options that are allowed.

![image](https://user-images.githubusercontent.com/5461649/213884525-42bd5160-0c02-466e-b9ef-324a1ea40014.png)

------

Let me know what you think - open to suggestions or changes!

I tested out both new commands locally and they work. I only copy/pasted the code into my kenv and did not build the app with the changes, so you will probably want to do that to make sure everything works with the build process.

![image](https://user-images.githubusercontent.com/5461649/213884705-0a8738db-a3ea-46a9-9f98-7a7727473919.png)
