### PR TITLE
fix(cli): Win32 OpenAsDiscussion

### DIFF
--- a/src/cli/share-script-as-discussion.ts
+++ b/src/cli/share-script-as-discussion.ts
@@ -38,9 +38,11 @@ ${content}
 
 copy(discussionPost)
 
-exec(
-  `open 'https://github.com/johnlindquist/kit/discussions/new?category=share'`
-)
+// Mac Method errors on Win32
+exec(`open 'https://github.com/johnlindquist/kit/discussions/new?category=share'`)
+
+// Win32 Method tested working
+open('https://github.com/johnlindquist/kit/discussions/new?category=share')
 
 let message = `Copied ${command} to clipboard as markdown`
 


### PR DESCRIPTION
Added function invocation that will work on Windows without any issues.

```ts
/**
 * Invocation: exec(`open 'url'`)
 * @throws Error(Main.log): 'open' is not recognized as an internal or external command, operable program or batch file.
 * 
 * Description:
 * It most likely errors out on the windows platform as it's interpreted as a CMD command if used with exec
 * 
 * Resolution: open('url)
 * 
 * Note:
 * It's uknown to me if this will invoke properly on Mac or Linux, as such the previous invocation was left untouched.
 */
```