### PR TITLE
feat(kit): ⚡ add hyper terminal support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/node-notifier": "8.0.2",
         "@types/shelljs": "0.8.11",
         "advanced-calculator": "1.1.0",
-        "esbuild": "^0.16.15",
+        "esbuild": "0.16.15",
         "file-icon": "5.1.0",
         "filesize": "9.0.11",
         "googlethis": "1.4.3",

--- a/src/platform/base.ts
+++ b/src/platform/base.ts
@@ -33,6 +33,12 @@ global.iterm = async command => {
   return ""
 }
 
+global.hyper = async command => {
+  unsupported()
+
+  return ""
+}
+
 global.selectKitEditor = async (reset = false) => {
   unsupported()
 

--- a/src/platform/darwin.ts
+++ b/src/platform/darwin.ts
@@ -68,21 +68,47 @@ global.iterm = async command => {
                 create window with default profile
             end try
         end if
-    
+
         delay 0.1
-    
+
         tell the first window to tell current session to write text ${command}
-        
+
+    end tell
+    `.trim()
+  return await global.applescript(script)
+}
+
+//TODO: refactor this work around if electron ever gets native osascript support
+// https://github.com/vercel/hyper/issues/3410
+// https://github.com/electron/electron/issues/4418
+global.hyper = async command => {
+  command = `"${command.replace(/"/g, '\\"')}"`
+  let script = `
+    tell application "Hyper"
+      activate
+      if application "Hyper" is running then
+          tell application "System Events" to keystroke "n" using command down
+      end if
+
+      delay 0.5
+
+      tell application "System Events"
+        if exists (window 1 of process "Hyper") then
+          keystroke ${command}
+          key code 36
+        end if
+      end tell
     end tell
     `.trim()
   return await global.applescript(script)
 }
 
 let terminalEditor = editor => async file => {
-  //TODO: Hyper? Other terminals?
+  //TODO: Other terminals?
   let supportedTerminalMap = {
     terminal: global.terminal,
     iterm: global.iterm,
+    hyper: global.hyper,
   }
 
   let possibleTerminals = () =>

--- a/src/types/kit.d.ts
+++ b/src/types/kit.d.ts
@@ -259,6 +259,7 @@ export interface KitApi {
 
   terminal: (script: string) => Promise<string>
   iterm: (iterm: string) => Promise<string>
+  hyper: (hyper: string) => Promise<string>
 
   onTabs: {
     name: string
@@ -355,6 +356,7 @@ declare global {
 
   var terminal: (script: string) => Promise<string>
   var iterm: (iterm: string) => Promise<string>
+  var hyper: (hyper: string) => Promise<string>
   var projectPath: PathFn
   var clearAllTimeouts: () => void
   var clearAllIntervals: () => void


### PR DESCRIPTION
adds support for opening/editing scripts in hyper terminal if vim/neovim/etc is your editor of choice. currently, applescript isn't natively supported in hyper since it's an electron app, but testing locally this seems to be a good workaround