### PR TITLE
Add info on Tailwind and petite-vue for widgets

### DIFF
--- a/API.md
+++ b/API.md
@@ -355,7 +355,8 @@ let folderPath = await selectFolder()
 
 <!-- value: https://github.com/johnlindquist/kit/blob/main/API.md -->
 
-A `widget` creates a new window using HTML.
+A `widget` creates a new window using HTML. The HTML can be styled via [Tailwind CSS](https://tailwindcss.com/docs/utility-first) class names.
+Templating and interactivity can be added via [petite-vue](https://github.com/vuejs/petite-vue).
 
 ### Details
 


### PR DESCRIPTION
Closes #1017 

A bit late on this, but [I offered](https://github.com/johnlindquist/kit/issues/1017#issuecomment-1397910694) in #1017 to clarify the widget docs by adding that widgets use `petite-vue` to add templating and interactivity. Here's the PR for it. Also made a mention of Tailwind as well.