### PR TITLE
Fixed the "take a screenshot" section

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1259,6 +1259,7 @@ const screenshotResults = await getScreenshotFromWebpage('https://legiblenews.co
 });
 
 await writeFile(home('news.png'), screenshotResults);
+```
 
 ## Scrape content from a webpage
 


### PR DESCRIPTION
The example in JS was missing the ``` for closing, making the next example (scrape content) to be rendered as part of the screenshot example. =)