### PR TITLE
fix: app launcher on Windows

### DIFF
--- a/src/main/app-launcher.ts
+++ b/src/main/app-launcher.ts
@@ -4,67 +4,65 @@ import { backToMainShortcut, cmd } from "../core/utils.js"
 
 let findAppsAndPrefs = async () => {
   log(`findAppsAndPrefs`)
-  let apps = await fileSearch("", {
-    onlyin: "/",
-    kMDItemContentType: "com.apple.application-bundle",
-  })
-  let manualAppDir = await readdir("/Applications")
-  apps = apps.concat(
-    manualAppDir
-      .filter(app => app.endsWith(".app"))
-      .map(app => `/Applications/${app}`)
-  )
-  // apps = _.uniq(apps.filter(a => !a.includes("Users")))
-  let prefs = await fileSearch("", {
-    onlyin: "/",
-    kind: "preferences",
-  })
-  return {
-    apps,
-    prefs,
+  if (process.platform === "darwin") {
+    let apps = await fileSearch("", {
+      onlyin: "/",
+      kMDItemContentType: "com.apple.application-bundle",
+    })
+    let manualAppDir = await readdir("/Applications")
+    apps = apps.concat(
+      manualAppDir
+        .filter(app => app.endsWith(".app"))
+        .map(app => `/Applications/${app}`)
+    )
+    // apps = _.uniq(apps.filter(a => !a.includes("Users")))
+    let prefs = await fileSearch("", {
+      onlyin: "/",
+      kind: "preferences",
+    })
+    return {
+      apps,
+      prefs,
+    }
+  } else if (process.platform === "win32") {
+    let globalApps = await fileSearch("", {
+      onlyin:
+        '"%ProgramData%\\Microsoft\\Windows\\Start Menu\\Programs"',
+      kind: "application",
+    })
+    let apps = await fileSearch("", {
+      onlyin:
+        '"%AppData%\\Microsoft\\Windows\\Start Menu\\Programs"',
+      kind: "application",
+    })
+    return {
+      apps: [...globalApps, ...apps],
+      prefs: [],
+    }
   }
 }
 let createChoices = async () => {
-  let { fileIconToFile } = await npm("file-icon")
+  let { extractIcon } = await npm("get-app-icon")
   setLoading(true)
   let { apps, prefs } = await findAppsAndPrefs()
-  let assetsPath = kitPath(
-    "assets",
-    "app-launcher",
-    "icons"
-  )
-  await ensureDir(assetsPath)
   let allApps = _.uniq(apps.concat(prefs))
 
-  let destination = allApps.map(appPath => {
-    let { base: appName } = path.parse(appPath)
-    return path.resolve(assetsPath, `${appName}.png`)
-  })
-
-  log(`Creating icons for ${allApps.length} apps`)
-  await fileIconToFile(allApps, {
-    size: 48,
-    destination,
-  })
-
-  log(`Done creating icons`)
-
   let choices = _.sortBy(
-    allApps.map(appPath => {
-      let { base: appName } = path.parse(appPath)
-      let destination = path.resolve(
-        assetsPath,
-        `${appName}.png`
-      )
+    await Promise.all(
+      allApps.map(async appPath => {
+        let { base: appName } = path.parse(appPath)
 
-      return {
-        name: appName.replace(".app", ""),
-        value: appPath,
-        description: appPath,
-        img: destination,
-        enter: `Open`,
-      }
-    }),
+        return {
+          name: appName.replace(/\.(app|lnk|url)\s*$/i, ""),
+          value: appPath,
+          description: appPath,
+          img: await extractIcon(appPath.trim()).catch(
+            () => undefined
+          ),
+          enter: `Open`,
+        }
+      })
+    ),
     ["value", "name"]
   )
 


### PR DESCRIPTION
This commit adds windows support for app-launcher on Windows.  It does so by getting apps on different paths when `process.platform === "win32"` and switching the icon npm package to `get-app-icon` which supports Windows.