### PR TITLE
Fix reveal-script description for Windows

### DIFF
--- a/src/cli/app-run.ts
+++ b/src/cli/app-run.ts
@@ -102,7 +102,7 @@ let scriptFlags: FlagsOptions = {
   },
   ["reveal-script"]: {
     name: "Reveal",
-    description: "Reveal the selected script in Finder",
+    description: `Reveal the selected script in ${isMac ? "Finder" : "Explorer"}`,
     shortcut: `${cmd}+shift+f`,
   },
   // ["share"]: {

--- a/src/cli/app-run.ts
+++ b/src/cli/app-run.ts
@@ -8,6 +8,7 @@ import {
   toggleBackground,
   run,
   cmd,
+  isMac
 } from "../core/utils.js"
 import { FlagsOptions, Script } from "../types/core.js"
 


### PR DESCRIPTION
On Windows, the "reveal-script" description is `Reveal the selected script in Finder`.

![image](https://user-images.githubusercontent.com/23557893/235754970-502c52f3-617a-498d-b331-ad2ecfdea622.png)

This PR fixes the message for Windows to `Reveal the selected script in Explorer`, using the global `isMac` variable I noticed was used elsewhere for this kind of description customization.
