### PR TITLE
Loosen the typings of `Shortcut["onPress"]` to allow an arbitrary return value

### DIFF
--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -193,7 +193,7 @@ export type Shortcut = {
   onPress?: (
     input: string,
     state: AppState
-  ) => void | Promise<void>
+  ) => unknown | Promise<unknown>
   bar?: "right" | "left" | ""
   flag?: string
   visible?: boolean


### PR DESCRIPTION
I don't anticipate the return value to be checked at any point in the future, thus allowing users to return whatever they want from the promise should be fine.

See this error for motivation:
![image](https://github.com/johnlindquist/kit/assets/7313176/6d7c747b-e700-47f1-9b9c-b543462f7817)

I'd argue it's generally good practice to allow user-defined callbacks to return `any`thing, which is commonly done by annotating the return type as `unknown`. This holds as long as no shenanigans like `(...) => typeof preventSubmit` are planned.