### PR TITLE
Add getMetadataFromGlobalAssignment AST parser

### DIFF
--- a/src/api/global.ts
+++ b/src/api/global.ts
@@ -10,6 +10,7 @@ import {
   knodePath,
   getLogFromScriptPath,
   createPathResolver,
+  parseScript
 } from "../core/utils.js"
 
 import { getScripts } from "../core/db.js"
@@ -19,8 +20,11 @@ import {
   formatDistanceToNow,
 } from "@johnlindquist/kit-internal/date-fns"
 
+global.metadata = {}
+
 global.actionFlag = ""
 global.getScripts = getScripts
+global.parseScript = parseScript
 
 performance.mark("run")
 

--- a/src/cli/duplicate.ts
+++ b/src/cli/duplicate.ts
@@ -4,10 +4,9 @@ import {
   checkIfCommandExists,
   stripName,
   kitMode,
-  stripMetadata,
-  uniq,
 } from "../core/utils.js"
 import { generate } from "@johnlindquist/kit-internal/project-name-generator"
+import { stripMetadata } from "../core/metadata"
 
 let examples = Array.from({ length: 3 })
   .map((_, i) => generate({ words: 2 }).dashed)

--- a/src/cli/edit-doc.ts
+++ b/src/cli/edit-doc.ts
@@ -2,8 +2,8 @@ import {
   escapeShortcut,
   closeShortcut,
   cmd,
-  setMetadata,
 } from "../core/utils.js"
+
 let scriptPath = await arg()
 // TODO: centralize .ts/.js finding logic
 let { name, dir } = path.parse(scriptPath)

--- a/src/cli/new-from-clipboard.ts
+++ b/src/cli/new-from-clipboard.ts
@@ -1,6 +1,6 @@
 // Description: Creates a new empty script you can invoke from the terminal
 
-import { parseMetadata } from "../core/utils.js"
+import { parseMetadata } from "../core/metadata.js"
 
 let content = await paste()
 

--- a/src/cli/new-from-protocol.ts
+++ b/src/cli/new-from-protocol.ts
@@ -7,7 +7,6 @@ import { highlightJavaScript } from "../api/kit.js"
 import {
   checkIfCommandExists,
   kitMode,
-  stripMetadata,
   uniq,
 } from "../core/utils.js"
 import {
@@ -15,6 +14,7 @@ import {
   prependImport,
 } from "./lib/utils.js"
 import { generate } from "@johnlindquist/kit-internal/project-name-generator"
+import { stripMetadata } from "../core/metadata.js"
 
 let examples = Array.from({ length: 3 })
   .map((_, i) => generate({ words: 2 }).dashed)

--- a/src/cli/new-from-url.ts
+++ b/src/cli/new-from-url.ts
@@ -3,9 +3,9 @@
 import { highlightJavaScript } from "../api/kit.js"
 import {
   checkIfCommandExists,
-  stripMetadata,
 } from "../core/utils.js"
 import { prependImport } from "./lib/utils.js"
+import { stripMetadata } from "../core/metadata.js"
 
 let url = await arg({
   placeholder: "Enter script url:",

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -2,7 +2,6 @@ import {
   checkIfCommandExists,
   stripName,
   kitMode,
-  stripMetadata,
   uniq,
   keywordInputTransformer,
 } from "../core/utils.js"
@@ -12,6 +11,7 @@ import {
 } from "./lib/utils.js"
 import { getUserDefaultMetadataMode } from "./metadata-mode.js"
 import { getEnvVar } from "../api/kit.js"
+import { stripMetadata } from "../core/metadata.js"
 
 let inputTransformer = keywordInputTransformer(arg?.keyword)
 

--- a/src/cli/snippet.ts
+++ b/src/cli/snippet.ts
@@ -10,7 +10,7 @@ import {
   prependImport,
 } from "./lib/utils.js"
 import { generate } from "@johnlindquist/kit-internal/project-name-generator"
-import { stripMetadata } from "../core/utils.js"
+import { stripMetadata } from "../core/metadata.js"
 
 let previewContent = ``
 if (arg?.content) {

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -1,0 +1,467 @@
+import { Identifier, Parser, Program, Property, SpreadElement, TemplateLiteral } from "acorn"
+import { Metadata, ScriptMetadata } from "../types/core"
+import tsPlugin from "acorn-typescript"
+import { ProcessType } from "./enum.js"
+import untildify from "untildify"
+import { friendlyShortcut, shortcutNormalizer } from "./shortcuts.js"
+
+const getMetadataFromComments = (
+  contents: string
+): Record<string, string> => {
+  const lines = contents.split("\n")
+  const metadata = {}
+  let commentStyle = null
+  let spaceRegex = null
+  let inMultilineComment = false
+  let multilineCommentEnd = null
+
+  const setCommentStyle = (style: string) => {
+    commentStyle = style
+    spaceRegex = new RegExp(`^${commentStyle} ?[^ ]`)
+  }
+
+  for (const line of lines) {
+    // Check for the start of a multiline comment block
+    if (
+      !inMultilineComment &&
+      (line.trim().startsWith("/*") ||
+        line.trim().startsWith("'''") ||
+        line.trim().startsWith("\"\"\"") ||
+        line.trim().match(/^: '/))
+    ) {
+      inMultilineComment = true
+      multilineCommentEnd = line.trim().startsWith("/*")
+        ? "*/"
+        : line.trim().startsWith(": '")
+          ? "'"
+          : line.trim().startsWith("'''")
+            ? "'''"
+            : "\"\"\""
+    }
+
+    // Check for the end of a multiline comment block
+    if (
+      inMultilineComment &&
+      line.trim().endsWith(multilineCommentEnd)
+    ) {
+      inMultilineComment = false
+      multilineCommentEnd = null
+      continue // Skip the end line of a multiline comment block
+    }
+
+    // Skip lines that are part of a multiline comment block
+    if (inMultilineComment) continue
+
+    // Determine the comment style based on the first encountered comment line
+    if (commentStyle === null) {
+      if (
+        line.startsWith("//") &&
+        (line[2] === " " || /[a-zA-Z]/.test(line[2]))
+      ) {
+        setCommentStyle("//")
+      } else if (
+        line.startsWith("#") &&
+        (line[1] === " " || /[a-zA-Z]/.test(line[1]))
+      ) {
+        setCommentStyle("#")
+      }
+    }
+
+    // Skip lines that don't start with the determined comment style
+    if (
+      commentStyle === null ||
+      (commentStyle && !line.startsWith(commentStyle))
+    )
+      continue
+
+    // Check for 0 or 1 space after the comment style
+    if (!line.match(spaceRegex)) continue
+
+    // Find the index of the first colon
+    const colonIndex = line.indexOf(":")
+    if (colonIndex === -1) continue
+
+    // Extract key and value based on the colon index
+    let key = line
+      .substring(commentStyle.length, colonIndex)
+      .trim()
+
+    if (key?.length > 0) {
+      key = key[0].toLowerCase() + key.slice(1)
+    }
+    const value = line.substring(colonIndex + 1).trim()
+
+    // Skip empty keys or values
+    if (!key || !value) {
+      continue
+    }
+
+    let parsedValue: string | boolean | number
+    let lowerValue = value.toLowerCase()
+    let lowerKey = key.toLowerCase()
+    switch (true) {
+      case lowerValue === "true":
+        parsedValue = true
+        break
+      case lowerValue === "false":
+        parsedValue = false
+        break
+      case lowerKey === "timeout":
+        parsedValue = parseInt(value, 10)
+        break
+      default:
+        parsedValue = value
+    }
+
+    // Only assign if the key hasn't been assigned before
+    if (!(key in metadata)) {
+      metadata[key] = parsedValue
+    }
+  }
+
+  return metadata
+}
+
+export function parseTypeScript(code: string) {
+  const parser = Parser.extend(
+    // @ts-expect-error Somehow these are not 100% compatible
+    tsPlugin({ allowSatisfies: true })
+  )
+  return parser.parse(code, {
+    sourceType: "module",
+    ecmaVersion: "latest"
+  })
+}
+
+function isOfType<
+  T extends { type: string },
+  TType extends string
+>(node: T, type: TType): node is T & { type: TType } {
+  return node.type === type
+}
+
+const SHORTCUT_ALLOWED_LITERALS = ["cmd", "ctrl", "opt"]
+const templateLiteralAsStringOrFail = (key: string, value: TemplateLiteral) => {
+  if (key !== "shortcut") {
+    throw Error(`Template strings are only allowed for the shortcut metadata with ${SHORTCUT_ALLOWED_LITERALS.join(", ")}`)
+  }
+
+  if (!value.expressions.every(x => x.type === "Identifier")) {
+    throw Error(`Encountered a template expression that is not an identifier: ` +
+      `${JSON.stringify(value.expressions, null, 2)}`)
+  }
+
+  const expressions = value.expressions as Identifier[]
+
+  const invalidExpressions = value.expressions.filter(exp =>
+    isOfType(exp, "Identifier") &&
+    !SHORTCUT_ALLOWED_LITERALS.includes(exp.name)
+  )
+
+  if (invalidExpressions.length > 0) {
+    throw Error(`Template strings are only allowed for the literals ${SHORTCUT_ALLOWED_LITERALS.join(", ")},` +
+      `but encountered ${invalidExpressions.join(", ")}`)
+  }
+
+  let parts = []
+  value.quasis.forEach((element, index) => {
+    parts.push(element.value.cooked);
+    if (index < expressions.length) {
+      parts.push(expressions[index].name);
+    }
+  });
+
+  return parts.join("")
+}
+
+const extractMetadataFromObjectExpression = (properties: (Property | SpreadElement)[]) =>
+  properties.reduce((acc, prop) => {
+    if (!isOfType(prop, "Property")) {
+      throw Error(`Entry in ObjectExpression is not a property, but a '${prop.type}'.`)
+    }
+
+    const key = prop.key
+    const value = prop.value
+
+    if (!isOfType(key, "Identifier")) {
+      throw Error("Key is not an Identifier")
+    }
+
+    switch (value.type) {
+      case 'Literal':
+        acc[key.name] = value.value ?? value.raw // RegExp requires the raw value
+        break
+      case 'TemplateLiteral':
+        acc[key.name] = templateLiteralAsStringOrFail(key.name, value)
+        warn(`Template literal: ${templateLiteralAsStringOrFail(key.name, value)}`)
+        break
+      default:
+        throw Error(
+          `Value is not a Literal, but a ${value.type}`
+        )
+    }
+
+    return acc
+  }, {})
+
+function getMetadataFromExport(
+  ast: Program
+): Partial<Metadata> {
+
+  for (const node of ast.body) {
+    if (
+      !isOfType(node, "ExportNamedDeclaration") ||
+      !node.declaration
+    ) {
+      continue
+    }
+
+    const declaration = node.declaration
+
+    if (
+      declaration.type !== "VariableDeclaration" ||
+      !declaration.declarations[0]
+    ) {
+      continue
+    }
+
+    const namedExport = declaration.declarations[0]
+
+    if (
+      !("name" in namedExport.id) ||
+      namedExport.id.name !== "metadata"
+    ) {
+      continue
+    }
+
+    if (namedExport.init?.type !== "ObjectExpression") {
+      continue
+    }
+
+    return extractMetadataFromObjectExpression(namedExport.init?.properties)
+  }
+
+  // Nothing found
+  return {}
+}
+
+function getMetadataFromGlobalAssignment(
+  ast: Program
+): Partial<Metadata> {
+  for (const node of ast.body) {
+    if (
+      !isOfType(node, "ExpressionStatement") ||
+      !node.expression ||
+      !isOfType(node.expression, "AssignmentExpression")
+    ) {
+      continue
+    }
+
+    const { left, right } = node.expression
+
+    if (!isOfType(left, "Identifier") || left.name !== "metadata") {
+      continue
+    }
+
+    if (!isOfType(right, "ObjectExpression")) {
+      continue
+    }
+
+    return extractMetadataFromObjectExpression(right.properties)
+  }
+
+  // Nothing found
+  return {}
+}
+
+const METADATA_EXPORT_PATTERN = /^\s*export\s*(const|var|let)\s*metadata/gm
+const METADATA_GLOBAL_ASSIGNMENT_PATTERN = /^\s*metadata\s*=\s*\{/gm
+
+//app
+export const getMetadata = (
+  contents: string,
+  filePath: string = undefined
+): Metadata => {
+  const fromComments = getMetadataFromComments(contents)
+
+  // RegExps are stateful
+  METADATA_EXPORT_PATTERN.lastIndex = 0
+  METADATA_GLOBAL_ASSIGNMENT_PATTERN.lastIndex = 0
+
+  const hasMetadataExport = METADATA_EXPORT_PATTERN.test(contents)
+  const hasMetadataGlobalAssignment = METADATA_GLOBAL_ASSIGNMENT_PATTERN.test(contents)
+
+  if (
+    !hasMetadataExport &&
+    !hasMetadataGlobalAssignment
+  ) {
+    // No convention-based metadata in file, return early
+    return fromComments
+  }
+
+  let ast: Program
+  try {
+    ast = parseTypeScript(contents)
+  } catch (err) {
+    filePath && warn(`Unable to generate AST for file at '${filePath}'`, err)
+    // TODO: May wanna introduce some error handling here. In my script version, I automatically added an error
+    //  message near the top of the user's file, indicating that their input couldn't be parsed...
+    //  acorn-typescript unfortunately doesn't support very modern syntax, like `const T` generics.
+    //  But it works in most cases.
+    return fromComments
+  }
+
+  try {
+    const fromCode: Partial<Metadata> = hasMetadataExport
+      ? getMetadataFromExport(ast)
+      : getMetadataFromGlobalAssignment(ast)
+
+    if (filePath && Object.keys(fromCode).length === 0) {
+      warn(`Convention-based metadata came back empty for file at '${filePath}'.`)
+    }
+
+    return { ...fromComments, ...fromCode }
+  } catch (err) {
+    filePath && warn(`Unable to parse metadata for file at '${filePath}'.`, err.toString())
+    return fromComments
+  }
+}
+
+//app
+export let postprocessMetadata = (
+  metadata: Metadata,
+  fileContents: string
+): ScriptMetadata => {
+  const {pass, ...scriptMetadata} = metadata;
+
+  const result: Partial<ScriptMetadata> = {
+    ...scriptMetadata,
+  }
+
+  if (pass !== undefined) {
+    result.pass = pass
+    ? typeof pass === "boolean"
+      ? pass
+      : pass.toString()
+    : false
+  }
+
+
+  if (metadata.shortcut) {
+    result.shortcut = shortcutNormalizer(metadata.shortcut)
+
+    result.friendlyShortcut = friendlyShortcut(
+      metadata.shortcut
+    )
+  }
+
+  if (metadata.shortcode) {
+    result.shortcode = metadata.shortcode
+      ?.trim()
+      ?.toLowerCase()
+  }
+
+  if (metadata.trigger) {
+    result.trigger = metadata.trigger?.trim()?.toLowerCase()
+  }
+
+  // An alias brings the script to the top of the list
+  if (metadata.alias) {
+    result.alias = metadata.alias?.trim().toLowerCase()
+  }
+
+  if (metadata.image) {
+    result.img = untildify(metadata.image)
+  }
+
+  result.type = metadata.schedule
+    ? ProcessType.Schedule
+    : result?.watch
+      ? ProcessType.Watch
+      : result?.system
+        ? ProcessType.System
+        : result?.background
+          ? ProcessType.Background
+          : ProcessType.Prompt
+
+  let tabs =
+    fileContents.match(
+      new RegExp(`(?<=^onTab[(]['"]).+?(?=['"])`, "gim")
+    ) || []
+
+  if (tabs?.length) {
+    result.tabs = tabs
+  }
+
+  let hasPreview = Boolean(
+    fileContents.match(/preview(:|\s{0,1}=)/gi)?.[0]
+  )
+  if (hasPreview) {
+    result.hasPreview = true
+  }
+
+  return result as unknown as ScriptMetadata
+}
+
+//app
+export let parseMetadata = (
+  fileContents: string,
+  filePath: string = undefined
+): ScriptMetadata => {
+  let metadata: Metadata = getMetadata(fileContents, filePath)
+
+  return postprocessMetadata(
+    metadata,
+    fileContents
+  )
+}
+
+export let setMetadata = (
+  contents: string,
+  overrides: {
+    [key: string]: string
+  }
+) => {
+  Object.entries(overrides).forEach(([key, value]) => {
+    let k = key[0].toUpperCase() + key.slice(1)
+    // if not exists, then add
+    if (
+      !contents.match(
+        new RegExp(`^\/\/\\s*(${key}|${k}):.*`, "gm")
+      )
+    ) {
+      // uppercase first letter
+      contents = `// ${k}: ${value}
+${contents}`.trim()
+    } else {
+      // if exists, then replace
+      contents = contents.replace(
+        new RegExp(`^\/\/\\s*(${key}|${k}):.*$`, "gm"),
+        `// ${k}: ${value}`
+      )
+    }
+  })
+  return contents
+}
+
+export let stripMetadata = (
+  fileContents: string,
+  exclude: string[] = []
+) => {
+  let excludeWithCommon = [
+    `http`,
+    `https`,
+    `TODO`,
+    `FIXME`,
+    `NOTE`
+  ].concat(exclude)
+
+  let negBehind = exclude.length
+    ? `(?<!(${excludeWithCommon.join("|")}))`
+    : ``
+
+  return fileContents.replace(
+    new RegExp(`(^//[^(:|\W|\n)]+${negBehind}:).+`, "gim"),
+    "$1"
+  )
+}

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -1,0 +1,5 @@
+import { platform } from "os"
+
+export const isWin = platform().startsWith("win")
+export const isMac = platform().startsWith("darwin")
+export const isLinux = platform().startsWith("linux")

--- a/src/core/shortcuts.ts
+++ b/src/core/shortcuts.ts
@@ -1,0 +1,36 @@
+import { isMac } from "./platform.js"
+
+//app
+export const shortcutNormalizer = (shortcut: string) =>
+  shortcut
+    ? shortcut
+      .replace(
+        /(option|opt|alt)/i,
+        isMac ? "Option" : "Alt"
+      )
+      .replace(/(ctl|cntrl|ctrl|control)/, "Control")
+      .replace(
+        /(command|cmd)/i,
+        isMac ? "Command" : "Control"
+      )
+      .replace(/(shift|shft)/i, "Shift")
+      .split(/\s/)
+      .filter(Boolean)
+      .map(part =>
+        (part[0].toUpperCase() + part.slice(1)).trim()
+      )
+      .join("+")
+    : ""
+
+export const friendlyShortcut = (shortcut: string) => {
+  let f = ""
+  if (shortcut.includes("Command+")) f += "cmd+"
+  if (shortcut.match(/(?<!Or)Control\+/)) f += "ctrl+"
+  if (shortcut.includes("Alt+")) f += "alt+"
+  if (shortcut.includes("Option+")) f += "opt+"
+  if (shortcut.includes("Shift+")) f += "shift+"
+  if (shortcut.includes("+"))
+    f += shortcut.split("+").pop()?.toLowerCase()
+
+  return f
+}

--- a/src/editor/types/kit-editor.d.ts
+++ b/src/editor/types/kit-editor.d.ts
@@ -139,6 +139,7 @@ export interface ScriptMetadata {
   recent?: boolean
   img?: string
   postfix?: string
+  pass?: string | boolean
 }
 
 export type Script = ScriptMetadata &
@@ -489,7 +490,7 @@ export interface Metadata {
   /** Associates a keyword with the script for easier discovery in the main menu. */
   keyword?: string
   /** Indicates that user input in the main menu should be passed as an argument to the script. */
-  pass?: boolean
+  pass?: boolean | string | RegExp
   /** Assigns the script to a specific group for organization in the main menu. */
   group?: string
   /** Excludes the script from appearing in the main menu. */
@@ -10393,9 +10394,24 @@ declare class UiohookNapi extends EventEmitter {
 export declare const uIOhook: UiohookNapi
 
 
+import {
+  format,
+  formatDistanceToNow,
+} from "@johnlindquist/kit-internal/date-fns"
 
-
-
+import {
+  Action,
+  ChannelHandler,
+  Choice,
+  Choices,
+  FlagsOptions,
+  Panel,
+  Preview,
+  PromptConfig,
+  ScoredChoice,
+  Script,
+  Shortcut,
+} from "./core"
 
 
 export interface Arg {
@@ -10735,6 +10751,7 @@ export interface Run {
 type Utils = typeof import("../core/utils")
 
 declare global {
+  var metadata: Metadata
   var path: PathSelector
   var edit: Edit
   var browse: Browse
@@ -10819,6 +10836,7 @@ declare global {
   var sortBy: Utils["sortBy"]
   var isUndefined: Utils["isUndefined"]
   var isString: Utils["isString"]
+  var parseScript: Utils["parseScript"]
 
   var createChoiceSearch: (
     choices: Choice[],
@@ -10859,17 +10877,42 @@ declare global {
 
 
 import core from "./core/enum"
+import {
+  Key,
+  Channel,
+  Mode,
+  statuses,
+  PROMPT as PROMPT_OBJECT,
+} from "../core/enum"
+
+
+
+import {
+  AppState,
+  ChannelHandler,
+  Choice,
+  Choices,
+  FlagsOptions,
+  PromptConfig,
+  PromptData,
+  ScoredChoice,
+  Script,
+  Shortcut,
+} from "./core"
+import {
+  BrowserWindowConstructorOptions,
+  Display,
+  Rectangle,
+} from "./electron"
 
 
 
 
-
-
-
-
-
-
-
+import {
+  UiohookKeyboardEvent,
+  UiohookMouseEvent,
+  UiohookWheelEvent,
+} from "./io"
 
 
 
@@ -12103,7 +12146,15 @@ declare global {
 }
 
 import * as shelljs from "shelljs/index"
-
+import {
+  add,
+  clone,
+  commit,
+  init,
+  pull,
+  push,
+  addRemote,
+} from "isomorphic-git"
 
 export type Trash = (
   input: string | readonly string[],
@@ -12747,7 +12798,11 @@ declare global {
 
 
 
-
+import {
+  BrowserWindowConstructorOptions,
+  Display,
+  Rectangle,
+} from "./electron"
 
 export type WidgetOptions =
   BrowserWindowConstructorOptions & {

--- a/src/main/browse.ts
+++ b/src/main/browse.ts
@@ -5,9 +5,8 @@
 
 import {
   escapeShortcut,
-  isMac,
-  isWin,
 } from "../core/utils.js"
+import { isMac, isWin } from "../core/platform.js"
 
 let actionFlags: {
   name: string

--- a/src/main/file-search.ts
+++ b/src/main/file-search.ts
@@ -5,8 +5,8 @@
 
 import {
   keywordInputTransformer,
-  isMac,
 } from "../core/utils.js"
+import { isMac } from "../core/platform.js"
 
 let actionFlags: {
   name: string

--- a/src/target/app.ts
+++ b/src/target/app.ts
@@ -63,7 +63,6 @@ import {
   formShortcuts,
   argShortcuts,
   smallShortcuts,
-  isMac,
   debounce,
   adjustPackageName,
   editorShortcuts,
@@ -78,6 +77,7 @@ import { Rectangle } from "../types/electron"
 import { Dirent } from "fs"
 import { pathToFileURL } from "url"
 import { PathConfig } from "../types/kit"
+import { isMac } from "../core/platform.js"
 
 interface DisplayChoicesProps
   extends Partial<PromptConfig> {

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -137,6 +137,7 @@ export interface ScriptMetadata {
   recent?: boolean
   img?: string
   postfix?: string
+  pass?: string | boolean
 }
 
 export type Script = ScriptMetadata &
@@ -487,7 +488,7 @@ export interface Metadata {
   /** Associates a keyword with the script for easier discovery in the main menu. */
   keyword?: string
   /** Indicates that user input in the main menu should be passed as an argument to the script. */
-  pass?: boolean
+  pass?: boolean | string | RegExp
   /** Assigns the script to a specific group for organization in the main menu. */
   group?: string
   /** Excludes the script from appearing in the main menu. */

--- a/src/types/kit.d.ts
+++ b/src/types/kit.d.ts
@@ -356,6 +356,7 @@ export interface Run {
 type Utils = typeof import("../core/utils")
 
 declare global {
+  var metadata: Metadata
   var path: PathSelector
   var edit: Edit
   var browse: Browse
@@ -440,6 +441,7 @@ declare global {
   var sortBy: Utils["sortBy"]
   var isUndefined: Utils["isUndefined"]
   var isString: Utils["isString"]
+  var parseScript: Utils["parseScript"]
 
   var createChoiceSearch: (
     choices: Choice[],


### PR DESCRIPTION
Also factored out the metadata-related stuff into a separate file, creating some additional files in the process to avoid circular imports.

Use this script to verify:

```ts
import "@johnlindquist/kit"

import assert from "node:assert/strict"
import { fileURLToPath } from "node:url"

const __filename = fileURLToPath(import.meta.url)

metadata = {
  name: "Metadata Test",
  alias: "md",
  enter: "lala",
  description: "Description",
  log: true,
  exclude: false,
  group: "Group",
  keyword: "Keyword",
  pass: /^abc$/gim,
  image: "test-image.jpg",
  schedule: "0 0 0 0 0",
  shortcode: "shortcode",
  shortcut: `${cmd}+k`,
  snippet: "snippet",
  system: "resume",
  timeout: 10,
  trigger: "trigger",
  watch: "aaaaaaaa",
  background: false,
}

const parsed = await parseScript(__filename)

const { shortcut: actualShortcut, ...actual } = pick(parsed, ...Object.keys(metadata))
const { shortcut: expectedShortcut, ...expected } = sanitize(metadata)

assert.deepEqual(actual, expected)
assert.equal(actualShortcut, expectedShortcut?.replace("ctrl", "Control").replace("cmd", "Cmd"))

await div(md(`✅ Metadata matches!\n~~~json\n${JSON.stringify({ ...actual, shortcut: actualShortcut }, null, 2)}\n~~~`))

function sanitize<T extends Record<string, any>>(md: T): T {
  return {
    ...md,
    pass: md.pass ? (typeof md.pass === "boolean" ? md.pass : md.pass.toString()) : false,
  }
}

function pick<T extends Record<string, any>, K extends string[]>(
  obj: T,
  ...props: K
): { [P in K[number]]: P extends keyof T ? T[P] : never } {
  return props.reduce(
    (result, prop) => {
      if (prop in obj) {
        result[prop] = obj[prop]
      }
      return result
    },
    {} as { [P in K[number]]: P extends keyof T ? T[P] : never },
  )
}
```