### PR TITLE
fix syntax error in test-sdk/ava.config.js

### DIFF
--- a/test-sdk/ava.config.js
+++ b/test-sdk/ava.config.js
@@ -4,7 +4,7 @@ export default {
   },
   verbose: true,
   files: [
-    "src/**/*.test.js"
+    "src/**/*.test.js",
     "test/**/*.test.js",
   ],
 }


### PR DESCRIPTION
Hey friend 👋🏼 

I was looking around for projects that use the `ai` SDK to try out [codemods for the upcoming v5 upgrade](https://github.com/vercel/ai/issues/6552) and found good old `kit`! Been a while, how is it going?

Anyway, running the codemod upgrade script surfaced this script error. Happy Friday ☀️ 